### PR TITLE
Versioning Page Sources

### DIFF
--- a/wordmapper/client/src/js/settings.js
+++ b/wordmapper/client/src/js/settings.js
@@ -39,6 +39,9 @@ Settings.prototype.hostConfig = {
   },
   'beta.blogs.harvard.edu': {
     'sourceSelector': '.textboxcontent'
+  },
+  'localhost': {
+    'sourceSelector': '.textboxcontent'
   }
 };
 Settings.prototype.load = function(page) {

--- a/wordmapper/server/src/database.js
+++ b/wordmapper/server/src/database.js
@@ -204,7 +204,7 @@ var pages = {
 			return find_max_version(t).then(function(data) {
 				return do_inserts(t, data.max_version + 1);
 			}, function() {
-				return do_inserts(t, 1);
+				return do_inserts(t, 0);
 			});
 		});
 	}

--- a/wordmapper/server/src/migrations/001.do.sql
+++ b/wordmapper/server/src/migrations/001.do.sql
@@ -31,7 +31,7 @@ CREATE TABLE page_source (
 	id serial PRIMARY KEY,
 	page_id integer not null REFERENCES page(id) ON DELETE CASCADE,
 	source_id integer not null REFERENCES source(id) ON DELETE CASCADE,
-	version integer not null default 1 CONSTRAINT version_check CHECK (version > 0),
+	version integer not null default 0 CONSTRAINT version_check CHECK (version >= 0),
 	created timestamp default current_timestamp
 );
 

--- a/wordmapper/server/src/migrations/001.do.sql
+++ b/wordmapper/server/src/migrations/001.do.sql
@@ -30,7 +30,9 @@ CREATE TABLE source (
 CREATE TABLE page_source (
 	id serial PRIMARY KEY,
 	page_id integer not null REFERENCES page(id) ON DELETE CASCADE,
-	source_id integer not null REFERENCES source(id) ON DELETE CASCADE
+	source_id integer not null REFERENCES source(id) ON DELETE CASCADE,
+	version integer not null default 1 CONSTRAINT version_check CHECK (version > 0),
+	created timestamp default current_timestamp
 );
 
 CREATE TABLE alignment (

--- a/wordmapper/server/src/repository.js
+++ b/wordmapper/server/src/repository.js
@@ -76,8 +76,14 @@ var repository = {
 			}).then(function(data) {
 				pageId = data.id;
 				return database.pages.getPageSourcesByUrl(url);
-			}).then(function() {
-				resolve(pageId);
+			}).then(function(rows) {
+				for(var i = 0, row; i < rows.length; i++) {
+					row = rows[i];
+					if (sourceIds.indexOf(row.source_id) === -1) {
+						return database.pages.createPageSources(pageId, sourceIds);
+					}
+				}
+				return Promise.resolve();
 			}, function() {
 				return database.pages.createPageSources(pageId, sourceIds);
 			}).then(function() {

--- a/wordmapper/server/src/routes/api.js
+++ b/wordmapper/server/src/routes/api.js
@@ -99,7 +99,9 @@ router.route('/sources')
 	repository.fetchSources(hashes, options).then(function(sources) {
 		winston.debug("fetchSources", hashes, options, sources);
 		if (sources.data.length == 0) {
-			res.status(404).json({ code: 404, message: "Sources not found" });
+			res.status(404).json({ code: 404, message: "No sources found" });
+		} else if(sources.data.length !== hashes.length) {
+			res.status(404).json({ code: 404, message: "One or more sources not found" });
 		} else {
 			res.json({ code: 200, message: "Fetched sources", data: sources });
 		}

--- a/wordmapper/server/src/sql/findPageSources.sql
+++ b/wordmapper/server/src/sql/findPageSources.sql
@@ -1,10 +1,13 @@
 SELECT
    ps.id        AS page_source_id
+  ,ps.created   AS page_source_created
+  ,ps.version   AS page_source_version
   ,ps.page_id   AS page_id
   ,ps.source_id AS source_id
-  ,p.url        AS url
-  ,s.hash       AS hash
+  ,s.hash       AS source_hash
+  ,p.url        AS page_url
 FROM page_source ps
 JOIN page p ON (ps.page_id = p.id)
 JOIN source s ON (ps.source_id = s.id)
 WHERE p.url = ${url}
+ORDER BY ps.version ASC, ps.source_id ASC


### PR DESCRIPTION
The tool currently expects that once a set of sources has been created and associated with a page, those sources will never change. Since this may not always be the case, the tool needs to be able to detect and track updated sources and associate them with the page. This addresses #19.

The solution implemented by this PR is to version the sources associated with the page. Any time one or more sources change, the sources are assigned a new version number (starting with 0 and incrementing up from there). Most of the time, a page will only ever have a single version, but this will allow for sites where the content may change frequently, particularly when it's being prepared.

Out of scope for this PR: ability for client to reconcile alignments on different versions of sources. 
