### PR TITLE
Update database.js

### DIFF
--- a/wordmapper/server/src/database.js
+++ b/wordmapper/server/src/database.js
@@ -1,3 +1,4 @@
+var path = require('path');
 var winston = require('winston');
 var config = require('./config');
 var auth = require('./auth');
@@ -13,7 +14,7 @@ var db = pgp(config.database);
 
 // Helper for linking to external query files: 
 function sql(file) {
-	return new pgp.QueryFile('./wordmapper/server/src/sql/'+file, {minify: true});
+	return new pgp.QueryFile(path.join(__dirname, './sql/' + file), {minify: true});
 }
 
 var users = {


### PR DESCRIPTION
* fixing the way you use the path to query files;
* WARNING: You should not use `QueryFile` inline, it is supposed to be created once. See the API.
* ERROR: You cannot use property `query` of type `QueryFile` directly, as by doing so you are breaking its logic for validating its own status, i.e. `query` is `null` when the object is in the error state.